### PR TITLE
Fix: Use userId instead of currentUser to fetch last bookings

### DIFF
--- a/src/booking/resolver/booking.resolver.ts
+++ b/src/booking/resolver/booking.resolver.ts
@@ -202,11 +202,12 @@ export class BookingResolver {
   @Query(() => [BookingEntity],{
     name: "getLastBookingsByClientId",
   })
-  // @UseGuards(JwtAuthGuard)
+  @UseGuards(JwtAuthGuard)
   getLastBookingsByClientId( 
     @Args("bookingType") bookingType: number,
-    @CurrentUser() user: UserEntity,
+    @Args("userId") userId: string,
+    
   ) {
-    return this.bookingService.getLastBookingsByClientId(user.id,bookingType);
+    return this.bookingService.getLastBookingsByClientId(userId,bookingType);
   }
 }


### PR DESCRIPTION
The `getLastBookingsByClientId` resolver now uses the provided `userId` argument instead of the `currentUser` to retrieve bookings. This change ensures consistent and accurate retrieval of bookings based on the specified user ID, regardless of the current user's context.